### PR TITLE
Hotfix - Rename ApplicationComponent to SingletonComponent

### DIFF
--- a/app/src/main/java/com/dahlaran/movshow/dependencyInjection/viewModel/NetworkModule.kt
+++ b/app/src/main/java/com/dahlaran/movshow/dependencyInjection/viewModel/NetworkModule.kt
@@ -6,7 +6,7 @@ import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
-@InstallIn(ApplicationComponent::class)
+@InstallIn(SingletonComponent::class)
 object NetworkModule {
 
     private const val API_URL = "https://api.tvmaze.com/"


### PR DESCRIPTION
ApplicationComponent is Deprecated in Dagger Version 2.30
ApplicationComponent removed in Dagger Version 2.31

SingletonComponent is used instead, it does the same things

https://stackoverflow.com/questions/65988186/error-cannot-find-symbol-dagger-hilt-installinvalue-applicationcomponent-c